### PR TITLE
[Video 1476] Add proxy configuration

### DIFF
--- a/Src/EngineIoClientDotNet.mono/Client/Socket.cs
+++ b/Src/EngineIoClientDotNet.mono/Client/Socket.cs
@@ -8,7 +8,7 @@ using Quobject.EngineIoClientDotNet.Thread;
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
-
+using System.Net;
 
 namespace Quobject.EngineIoClientDotNet.Client
 {
@@ -57,6 +57,7 @@ namespace Quobject.EngineIoClientDotNet.Client
         private string Hostname;
         private string Path;
         private string TimestampParam;
+        private string ProxyAddress;
         private ImmutableList<string> Transports;
         private ImmutableList<string> Upgrades;
         private Dictionary<string, string> Query;
@@ -166,7 +167,7 @@ namespace Quobject.EngineIoClientDotNet.Client
                 ServerCertificate.IgnoreServerCertificateValidation();
             }
             ExtraHeaders = options.ExtraHeaders;
-
+            ProxyAddress = options.ProxyAddress;
         }
 
         public Socket Open()
@@ -218,7 +219,8 @@ namespace Quobject.EngineIoClientDotNet.Client
                 ForceBase64 = this.ForceBase64,
                 ForceJsonp = this.ForceJsonp,
                 Cookies = this.Cookies,
-                ExtraHeaders = this.ExtraHeaders
+                ExtraHeaders = this.ExtraHeaders,
+                ProxyAddress = this.ProxyAddress
             };
 
             if (name == WebSocket.NAME)
@@ -383,9 +385,7 @@ namespace Quobject.EngineIoClientDotNet.Client
                 }
 
                 return opts;
-            }
-
-    
+            }   
         }
 
 

--- a/Src/EngineIoClientDotNet.mono/Client/Transport.cs
+++ b/Src/EngineIoClientDotNet.mono/Client/Transport.cs
@@ -191,6 +191,7 @@ namespace Quobject.EngineIoClientDotNet.Client
             internal Socket Socket;
             public Dictionary<string, string> Cookies = new Dictionary<string, string>();
             public Dictionary<string, string> ExtraHeaders = new Dictionary<string, string>();
+            public string ProxyAddress;
 
             public string GetCookiesAsString()
             {

--- a/Src/EngineIoClientDotNet.net45/.vs/config/applicationhost.config
+++ b/Src/EngineIoClientDotNet.net45/.vs/config/applicationhost.config
@@ -163,7 +163,7 @@
             </site>
             <site name="grunt" id="2">
                 <application path="/" applicationPool="Clr4IntegratedAppPool">
-                    <virtualDirectory path="/" physicalPath="C:\EngineIoClientDotNet\grunt" />
+                    <virtualDirectory path="/" physicalPath="C:\Projects\EngineIoClientDotNet\grunt" />
                 </application>
                 <bindings>
                     <binding protocol="http" bindingInformation="*:8678:localhost" />
@@ -171,7 +171,7 @@
             </site>
             <site name="TestServer" id="3">
                 <application path="/" applicationPool="Clr4IntegratedAppPool">
-                    <virtualDirectory path="/" physicalPath="C:\EngineIoClientDotNet\TestServer" />
+                    <virtualDirectory path="/" physicalPath="C:\Projects\EngineIoClientDotNet\TestServer" />
                 </application>
                 <bindings>
                     <binding protocol="http" bindingInformation="*:8671:localhost" />

--- a/Src/EngineIoClientDotNet.net45/EngineIoClientDotNet.net45.csproj
+++ b/Src/EngineIoClientDotNet.net45/EngineIoClientDotNet.net45.csproj
@@ -8,7 +8,7 @@
     <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>EngineIoClientDotNet</RootNamespace>
-    <AssemblyName>EngineIoClientDotNet</AssemblyName>
+    <AssemblyName>AtellisShared.EngineIoClientDotNet</AssemblyName>
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <NuGetPackageImportStamp>1fcf80f3</NuGetPackageImportStamp>

--- a/Src/EngineIoClientDotNet.net45/EngineIoClientDotNet.net45.nuspec
+++ b/Src/EngineIoClientDotNet.net45/EngineIoClientDotNet.net45.nuspec
@@ -6,13 +6,10 @@
     <title>$title$</title>
     <authors>$author$</authors>
     <owners>$author$</owners>
-    <licenseUrl>http://LICENSE_URL_HERE_OR_DELETE_THIS_LINE</licenseUrl>
-    <projectUrl>http://PROJECT_URL_HERE_OR_DELETE_THIS_LINE</projectUrl>
-    <iconUrl>http://ICON_URL_HERE_OR_DELETE_THIS_LINE</iconUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>$description$</description>
-    <releaseNotes>Summary of changes made in this release of the package.</releaseNotes>
-    <copyright>Copyright 2014</copyright>
-    <tags>Tag1 Tag2</tags>
+    <releaseNotes></releaseNotes>
+    <copyright>Copyright 2020</copyright>
+    <tags></tags>
   </metadata>
 </package>

--- a/Src/EngineIoClientDotNet.net45/Properties/AssemblyInfo.cs
+++ b/Src/EngineIoClientDotNet.net45/Properties/AssemblyInfo.cs
@@ -5,11 +5,11 @@ using System.Runtime.InteropServices;
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
 [assembly: AssemblyTitle("EngineIoClientDotNet")]
-[assembly: AssemblyDescription("Engine.IO Client Library for .Net")]
+[assembly: AssemblyDescription("Forked Engine.IO Client Library for .Net (original by Quobject Software)")]
 [assembly: AssemblyConfiguration("")]
-[assembly: AssemblyCompany("Quobject Software")]
+[assembly: AssemblyCompany("Attelis Inc.")]
 [assembly: AssemblyProduct("EngineIoClientDotNet")]
-[assembly: AssemblyCopyright("Copyright ©  2017")]
+[assembly: AssemblyCopyright("Copyright ©  2020")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 
@@ -31,5 +31,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.2")]
-[assembly: AssemblyFileVersion("1.0.2")]
+[assembly: AssemblyVersion("1.0.3")]
+[assembly: AssemblyFileVersion("1.0.3")]


### PR DESCRIPTION
Updated Engine library to take optional ProxyAddress value. IF the ProxyAddress is present, the WebSocket transport will parse and pass the IPEndPoint to the undelying web socket.

Will get builds going and pushing to our private repo once merged. I updated the NuSpec file in anticipation.